### PR TITLE
build: Add optimized release and dev profiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,3 +51,13 @@ path = "mc-oauth"
 
 [lints.clippy]
 pedantic = "deny"
+
+[profile.release]
+opt-level = "z"
+lto = "fat"
+codegen-units = 1
+panic = "abort"
+strip = true
+
+[profile.dev]
+opt-level = 1


### PR DESCRIPTION
Configure release profile with size optimizations (opt-level "z", fat LTO, strip) and dev profile with opt-level 1 for faster builds.